### PR TITLE
Add `sync_all` script for daily cron

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 cfg.toml
+/src/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-cfg.toml
+/cfg.toml
+/main.db
 /src/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Operational notes to the README. Explanations of some undocumented Homu features/behaviors.
+- Script to sync all repos' PR status from GitHub via Heroku scheduler
 
 ## [v0.2.1]
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,25 @@ credentials -- we'll do that in a bit.
 
 From this point, I'll refer to the name of your Heroku app as `$HEROKU_APP`.
 
+### Schedule synchronization
+
+Homu stores information about open PRs in a SQLite database that is destroyed every night, when Heroku
+automatically restarts the Homu web dyno. Rebuild the database of PRs automatically by running the
+`sync_all.sh` script from this repo once per day, after the dyno has been restarted.
+
+- Set the env var APP_URL to the full URL of your app. For example,
+  "https://homu.herokuapp.com". If you are pushing this commit to an existing
+  Heroku app, you will also need to set `HOMU_WEB_SECRET` to something like
+  `openssl rand -hex 20`.
+- Visit dashboard.heroku.com and open the Metrics tab to find out what time
+  Heroku restarts your dyno each night. It will be a blue dot on the top graph,
+  and will tell you the exact time when you hover over the dot with your mouse.
+- Run `heroku addons:add scheduler` to add the scheduler to your app, then run
+  `heroku addons:open scheduler` to open the scheduler admin panel.
+- Add a new job, and choose a time that is shortly after the scheduled restart
+  of your dyno every night. Set the job's frequency to "Daily", and set the
+  command to `bash sync_all.sh`.
+
 ### Under the `$HOMU_BOT` account
 
 Login with your `$HOMU_BOT` account and perform these steps:
@@ -115,7 +134,7 @@ space-separated list of repo slugs e.g. "japaric/homu-on-heroku rust-lang/rust".
 the repos that must always pass AppVeyor CI. If a repository must pass both AppVeyor and Travis then
 it must appear in both lists.
 
-After updating these variables to not be empty, your Heroku app should get to the point where it
+After updating these variables, your Heroku app should get to the point where it
 doesn't crash and it should render its dashboard. Head to `https://$HEROKU_APP.herokuapp.com` to
 confirm.
 

--- a/app.json
+++ b/app.json
@@ -31,6 +31,10 @@
         "HOMU_REVIEWERS": {
             "description": "Space separated list of GitHub users that have \"r+\" rights. Example value: \"larry moe curly\" but without the double quotes.",
             "value": "you can fill this later"
+        },
+        "HOMU_WEB_SECRET": {
+            "description": "Some \"secret\" that the sync_all script will use.",
+            "generator": "secret"
         }
     }
 }

--- a/cfg.template.toml
+++ b/cfg.template.toml
@@ -17,6 +17,9 @@ status_based_exemption = {{ homu.git.local_git }}
 
 [web]
 port = {{ homu.web.port }}
+{% if homu.web.secret %}
+secret = "{{ homu.web.secret }}"
+{% endif %}
 
 {% for repo in homu.repos %}
 [repo.'{{ repo.slug }}']

--- a/launch.py
+++ b/launch.py
@@ -64,6 +64,9 @@ os.makedirs(os.path.join(os.path.expanduser('~'), '.ssh'), exist_ok=True)
 if os.path.isfile(os.path.expanduser('~/.ssh/known_hosts')):
     # grep exits 0 (which becomes false) if it finds the pattern
     github_unknown = bool(os.system('grep "^github.com " ~/.ssh/known_hosts > /dev/null'))
+else:
+    github_unknown = True
+
 if github_unknown:
     utils.logged_call(['sh', '-c',
                        'ssh-keyscan github.com >> ~/.ssh/known_hosts'])

--- a/launch.py
+++ b/launch.py
@@ -60,8 +60,11 @@ with open('cfg.toml', 'w') as f:
     f.write(template.render(homu=homu))
 
 os.makedirs(os.path.join(os.path.expanduser('~'), '.ssh'), exist_ok=True)
-# grep exits 0 (which is false) if it finds the pattern
-if os.system('grep "^github.com " ~/.ssh/known_hosts > /dev/null'):
+
+if os.path.isfile(os.path.expanduser('~/.ssh/known_hosts')):
+    # grep exits 0 (which becomes false) if it finds the pattern
+    github_unknown = bool(os.system('grep "^github.com " ~/.ssh/known_hosts > /dev/null'))
+if github_unknown:
     utils.logged_call(['sh', '-c',
                        'ssh-keyscan github.com >> ~/.ssh/known_hosts'])
 

--- a/launch.py
+++ b/launch.py
@@ -13,6 +13,7 @@ admin_secret = os.environ.get('HOMU_WEB_SECRET', '')
 
 repos = {}
 
+
 def append(slug, ci):
     if slug in repos:
         if ci == 'appveyor':

--- a/launch.py
+++ b/launch.py
@@ -63,7 +63,8 @@ os.makedirs(os.path.join(os.path.expanduser('~'), '.ssh'), exist_ok=True)
 
 if os.path.isfile(os.path.expanduser('~/.ssh/known_hosts')):
     # grep exits 0 (which becomes false) if it finds the pattern
-    github_unknown = bool(os.system('grep "^github.com " ~/.ssh/known_hosts > /dev/null'))
+    exit_code = os.system('grep "^github.com " ~/.ssh/known_hosts > /dev/null')
+    github_unknown = bool(exit_code)
 else:
     github_unknown = True
 

--- a/launch.py
+++ b/launch.py
@@ -57,8 +57,10 @@ homu = {
 with open('cfg.toml', 'w') as f:
     f.write(template.render(homu=homu))
 
-os.makedirs(os.path.join(os.path.expanduser('~'), '.ssh'))
-utils.logged_call(['sh', '-c',
-                   'ssh-keyscan -H github.com >> ~/.ssh/known_hosts'])
+os.makedirs(os.path.join(os.path.expanduser('~'), '.ssh'), exist_ok=True)
+# grep exits 0 (which is false) if it finds the pattern
+if os.system('grep "^github.com " ~/.ssh/known_hosts > /dev/null'):
+    utils.logged_call(['sh', '-c',
+                       'ssh-keyscan github.com >> ~/.ssh/known_hosts'])
 
 sys.exit(main())

--- a/launch.py
+++ b/launch.py
@@ -9,6 +9,7 @@ with open('cfg.template.toml') as f:
     template = Template(f.read())
 
 ssh_key = os.environ.get('GIT_SSH_KEY', '')
+admin_secret = os.environ.get('HOMU_WEB_SECRET', '')
 
 repos = {}
 
@@ -51,6 +52,7 @@ homu = {
     'reviewers': os.environ['HOMU_REVIEWERS'].split(' '),
     'web': {
         'port': os.environ['PORT'],
+        'secret': admin_secret if admin_secret else 'false'
     },
 }
 

--- a/sync_all.sh
+++ b/sync_all.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+curl -X "POST" "$APP_URL/admin" \
+     -H "Content-Type: application/json; charset=utf-8" \
+     -d "{\"secret\":\"$HOMU_WEB_SECRET\",\"cmd\":\"sync_all\"}"


### PR DESCRIPTION
Homu stores information about open PRs in a SQLite database that is destroyed every night, when Heroku automatically restarts the Homu web dyno. Rebuild the database of PRs automatically by running the `sync_all.sh` script from this repo once per day, after the dyno has been restarted.

Fixes #5.