### PR TITLE
Support Solano CI, allow empty repo lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Operational notes to the README. Explanations of some undocumented Homu features/behaviors.
 - Script to sync all repos' PR status from GitHub via Heroku scheduler
+- Allow any of the CI repo lists to be blank.
 
 ## [v0.2.1]
 

--- a/app.json
+++ b/app.json
@@ -22,11 +22,17 @@
         },
         "HOMU_APPVEYOR_REPOS": {
             "description": "Space separated list of GitHub repositories, in $OWNER/$REPO format, that Homu watches over and must always pass AppVeyor CI. Example value: \"rust-lang/rust rust-lang/libc\" but without the double quotes.",
-            "value": "you can fill this later"
+            "value": "you can fill this later",
+            "required": false
         },
         "HOMU_TRAVIS_REPOS": {
             "description": "Pretty much the same as HOMU_APPVEYOR_REPOS. But these repositories must always pass Travis CI",
-            "value": "you can fill this later"
+            "value": "organization/some_repo other-org/other-repo"
+        },
+        "HOMU_SOLANO_REPOS": {
+            "description": "Pretty much the same as HOMU_APPVEYOR_REPOS. But these repositories must always pass Solano CI",
+            "value": "you can fill this later",
+            "required": false
         },
         "HOMU_REVIEWERS": {
             "description": "Space separated list of GitHub users that have \"r+\" rights. Example value: \"larry moe curly\" but without the double quotes.",

--- a/cfg.template.toml
+++ b/cfg.template.toml
@@ -16,7 +16,7 @@ ssh_key = """{{ homu.git.ssh_key}}"""
 status_based_exemption = {{ homu.git.local_git }}
 
 [web]
-host = {{ homu.web.host }}
+host = "{{ homu.web.host }}"
 port = {{ homu.web.port }}
 {% if homu.web.secret %}
 secret = "{{ homu.web.secret }}"

--- a/cfg.template.toml
+++ b/cfg.template.toml
@@ -16,6 +16,7 @@ ssh_key = """{{ homu.git.ssh_key}}"""
 status_based_exemption = {{ homu.git.local_git }}
 
 [web]
+host = {{ homu.web.host }}
 port = {{ homu.web.port }}
 {% if homu.web.secret %}
 secret = "{{ homu.web.secret }}"

--- a/cfg.template.toml
+++ b/cfg.template.toml
@@ -38,14 +38,17 @@ secret = "{{ homu.gh.webhook_secret }}"
 
 {% if repo.appveyor %}
 [repo.'{{ repo.slug }}'.status.appveyor]
-
 context = "continuous-integration/appveyor/branch"
 {% endif %}
 
 {% if repo.travis %}
 [repo.'{{ repo.slug }}'.status.travis]
-
 context = "continuous-integration/travis-ci/push"
+{% endif %}
+
+{% if repo.solano %}
+[repo.'{{ repo.slug }}'.status.solano]
+context = "ci/solano-ci"
 {% endif %}
 
 {% endfor %}

--- a/launch.py
+++ b/launch.py
@@ -36,6 +36,7 @@ def append(slug, ci):
             'solano': True if ci == 'solano' else False,
         }
 
+
 if os.environ.get('HOMU_APPVEYOR_REPOS'):
     for slug in os.environ['HOMU_APPVEYOR_REPOS'].split(' '):
         append(slug, 'appveyor')

--- a/launch.py
+++ b/launch.py
@@ -62,6 +62,7 @@ homu = {
     'repos': repos.values(),
     'reviewers': os.environ['HOMU_REVIEWERS'].split(' '),
     'web': {
+        'host': 'localhost',
         'port': os.environ['PORT'],
         'secret': admin_secret if admin_secret else 'false'
     },

--- a/launch.py
+++ b/launch.py
@@ -19,6 +19,9 @@ def append(slug, ci):
         if ci == 'appveyor':
             repos[slug]['appveyor'] = True
 
+        if ci == 'solano':
+            repos[slug]['solano'] = True
+
         if ci == 'travis':
             repos[slug]['travis'] = True
     else:
@@ -30,6 +33,7 @@ def append(slug, ci):
             'owner': owner,
             'slug': slug,
             'travis': True if ci == 'travis' else False,
+            'solano': True if ci == 'solano' else False,
         }
 
 for slug in os.environ['HOMU_APPVEYOR_REPOS'].split(' '):
@@ -37,6 +41,9 @@ for slug in os.environ['HOMU_APPVEYOR_REPOS'].split(' '):
 
 for slug in os.environ['HOMU_TRAVIS_REPOS'].split(' '):
     append(slug, 'travis')
+
+for slug in os.environ['HOMU_SOLANO_REPOS'].split(' '):
+    append(slug, 'solano')
 
 homu = {
     'gh': {

--- a/launch.py
+++ b/launch.py
@@ -36,14 +36,17 @@ def append(slug, ci):
             'solano': True if ci == 'solano' else False,
         }
 
-for slug in os.environ['HOMU_APPVEYOR_REPOS'].split(' '):
-    append(slug, 'appveyor')
+if os.environ.get('HOMU_APPVEYOR_REPOS'):
+    for slug in os.environ['HOMU_APPVEYOR_REPOS'].split(' '):
+        append(slug, 'appveyor')
 
-for slug in os.environ['HOMU_TRAVIS_REPOS'].split(' '):
-    append(slug, 'travis')
+if os.environ.get('HOMU_TRAVIS_REPOS'):
+    for slug in os.environ['HOMU_TRAVIS_REPOS'].split(' '):
+        append(slug, 'travis')
 
-for slug in os.environ['HOMU_SOLANO_REPOS'].split(' '):
-    append(slug, 'solano')
+if os.environ.get('HOMU_SOLANO_REPOS'):
+    for slug in os.environ['HOMU_SOLANO_REPOS'].split(' '):
+        append(slug, 'solano')
 
 homu = {
     'gh': {

--- a/launch.py
+++ b/launch.py
@@ -62,7 +62,7 @@ homu = {
     'repos': repos.values(),
     'reviewers': os.environ['HOMU_REVIEWERS'].split(' '),
     'web': {
-        'host': '127.0.0.1',
+        'host': '0.0.0.0',
         'port': os.environ['PORT'],
         'secret': admin_secret if admin_secret else 'false'
     },

--- a/launch.py
+++ b/launch.py
@@ -62,7 +62,7 @@ homu = {
     'repos': repos.values(),
     'reviewers': os.environ['HOMU_REVIEWERS'].split(' '),
     'web': {
-        'host': 'localhost',
+        'host': '127.0.0.1',
         'port': os.environ['PORT'],
         'secret': admin_secret if admin_secret else 'false'
     },


### PR DESCRIPTION
These commits add support for the Solano CI system (via the GitHub status API), and allow any of the environment variables for a single CI server to be empty. Some Homu users have zero repos on a particular CI system, and this prevents crashes in that case.