### PR TITLE
Add automatic repo sync during startup

### DIFF
--- a/cfg.template.toml
+++ b/cfg.template.toml
@@ -21,6 +21,7 @@ port = {{ homu.web.port }}
 {% if homu.web.secret %}
 secret = "{{ homu.web.secret }}"
 {% endif %}
+sync_on_start = {{ homu.web.sync_on_start }}
 
 {% for repo in homu.repos %}
 [repo.'{{ repo.slug }}']

--- a/launch.py
+++ b/launch.py
@@ -10,6 +10,7 @@ with open('cfg.template.toml') as f:
 
 ssh_key = os.environ.get('GIT_SSH_KEY', '')
 admin_secret = os.environ.get('HOMU_WEB_SECRET', '')
+sync_on_start = os.environ.get('SYNC_ON_START', 'false')
 
 repos = {}
 
@@ -65,7 +66,8 @@ homu = {
     'web': {
         'host': '0.0.0.0',
         'port': os.environ['PORT'],
-        'secret': admin_secret if admin_secret else 'false'
+        'secret': admin_secret if admin_secret else 'false',
+        'sync_on_start': 'true' if sync_on_start != 'false' else 'false'
     },
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
--e git://github.com/servo/homu.git@0c9b5ed9dc1e8bd218d0f05e4c9bc69ffb075f21#egg=homu
+-e git://github.com/servo/homu.git@ff3f43f5dec8709df9dcad89996cdd72ccc4b651#egg=homu
 Jinja2==2.8


### PR DESCRIPTION
It turns out that Heroku lets any web process run for 24 hours from the
time it last started. That means that the external sync_all script
running in a scheduler can easily get very far out of sync with the time
that Heroku restarts the web process. :/ To resolve this completely, I
added a new option to Homu: sync on startup. It runs the exact same code
as the external `sync_all` script does, but automatically and
immediately when the web process boots.

This isn't completely ideal, since it means that homu-on-heroku moves
off of the mainline Servo fork of Homu, but it has the positive effect
of making homu-on-heroku exactly as useful as homu.io is. This change
means that even on Heroku, Homu always knows about every single PR, and
never needs any manual or external syncing. We're using this change to
great effect in @bundlerbot with the Bundler and RubyGems open source
projects.

(I've opened a PR to merge support for this to upstream at https://github.com/servo/homu/pull/66. I'm happy to update this PR to point back to servo/homu assuming that PR is merged.)